### PR TITLE
ChatGPT response for issue #28

### DIFF
--- a/simpsons.csv
+++ b/simpsons.csv
@@ -1,20 +1,20 @@
-Barney,Gumble,742 Evergreen Terrace,Springfield,IL,62704,$33,12/14/2011
-Homer,Simpson,742 Evergreen Terrace,Springfield,IL,62704,$55,10/5/2008
-Marge,Simpson,742 Evergreen Terrace,Springfield,IL,62704,$79,8/22/2010
-Lisa,Simpson,742 Evergreen Terrace,Springfield,IL,62704,$53,9/9/2009
-Maggie,Simpson,742 Evergreen Terrace,Springfield,IL,62704,$18,11/2/2012
-Bart,Simpson,742 Evergreen Terrace,Springfield,IL,62704,$42,7/1/2007
-Ned,Flanders,744 Evergreen Terrace,Springfield,IL,62704,$65,6/23/2013
-Maude,Flanders,744 Evergreen Terrace,Springfield,IL,62704,$8,2/10/2006
-Rod,Flanders,744 Evergreen Terrace,Springfield,IL,62704,$17,4/17/2010
-Todd,Flanders,744 Evergreen Terrace,Springfield,IL,62704,$23,1/23/2014
-Krusty,The Clown,13 Krusty Lane,Springfield,IL,62704,$91,3/29/2008
-Sideshow,Bob,2465 Riverside Dr,Springfield,IL,62704,$43,5/24/2015
-Milhouse,Van Houten,744 Evergreen Terrace,Springfield,IL,62704,$35,9/30/2009
-Apu,Nahasapeemapetilon,59 Maple St,Springfield,IL,62704,$39,11/13/2011
-Moe,Szellak,486-6101 Moe's Tavern,Springfield,IL,62704,$29,2/1/2008
-Lionel,Hutz,502 Center St,Springfield,IL,62704,$98,12/14/2007
-Troy,McClure,744 Evergreen Terrace,Springfield,IL,62704,$77,7/6/2010
-Patty,Bouvier,742 Evergreen Terrace,Springfield,IL,62704,$14,8/12/2013
-Selma,Bouvier,742 Evergreen Terrace,Springfield,IL,62704,$61,4/4/2006
-Wiggum,Clancy,123 Main St,Springfield,IL,62704,$71,1/20/2015
+Glenn,Quagmire,31 Spooner Street,Quahog,RI,02860,$33,12/14/2011
+Peter,Griffin,31 Spooner Street,Quahog,RI,02860,$55,10/5/2008
+Lois,Griffin,31 Spooner Street,Quahog,RI,02860,$79,8/22/2010
+Meg,Griffin,31 Spooner Street,Quahog,RI,02860,$53,9/9/2009
+Stewie,Griffin,31 Spooner Street,Quahog,RI,02860,$18,11/2/2012
+Chris,Griffin,31 Spooner Street,Quahog,RI,02860,$42,7/1/2007
+Cleveland,Brown,33 Spooner Street,Quahog,RI,02860,$65,6/23/2013
+Donna,Brown,33 Spooner Street,Quahog,RI,02860,$8,2/10/2006
+Cleveland Jr.,Brown,33 Spooner Street,Quahog,RI,02860,$17,4/17/2010
+Roberta,Brown,33 Spooner Street,Quahog,RI,02860,$23,1/23/2014
+Mort,Goldman,87 Quahog St,Quahog,RI,02860,$91,3/29/2008
+Joe,Swanson,29 Spooner Street,Quahog,RI,02860,$43,5/24/2015
+Neil,Goldman,87 Quahog St,Quahog,RI,02860,$35,9/30/2009
+Tom,Tucker,45 Pine St,Quahog,RI,02860,$39,11/13/2011
+Quagmire,Ida,41 Spooner St,Quahog,RI,02860,$29,2/1/2008
+Angela,Smith,25 Pawtucket Ave,Quahog,RI,02860,$98,12/14/2007
+Diane,Simmons,23 Oak St,Quahog,RI,02860,$77,7/6/2010
+Joyce,Kinney,31 Quahog Rd,Quahog,RI,02860,$14,8/12/2013
+Herbert,Oldman,35 Spooner St,Quahog,RI,02860,$61,4/4/2006
+Adam,West,55 Elm St,Quahog,RI,02860,$71,1/20/2015


### PR DESCRIPTION
Adding a file containing the ChatGPT response for issue #28:

Glenn,Quagmire,31 Spooner Street,Quahog,RI,02860,$33,12/14/2011
Peter,Griffin,31 Spooner Street,Quahog,RI,02860,$55,10/5/2008
Lois,Griffin,31 Spooner Street,Quahog,RI,02860,$79,8/22/2010
Meg,Griffin,31 Spooner Street,Quahog,RI,02860,$53,9/9/2009
Stewie,Griffin,31 Spooner Street,Quahog,RI,02860,$18,11/2/2012
Chris,Griffin,31 Spooner Street,Quahog,RI,02860,$42,7/1/2007
Cleveland,Brown,33 Spooner Street,Quahog,RI,02860,$65,6/23/2013
Donna,Brown,33 Spooner Street,Quahog,RI,02860,$8,2/10/2006
Cleveland Jr.,Brown,33 Spooner Street,Quahog,RI,02860,$17,4/17/2010
Roberta,Brown,33 Spooner Street,Quahog,RI,02860,$23,1/23/2014
Mort,Goldman,87 Quahog St,Quahog,RI,02860,$91,3/29/2008
Joe,Swanson,29 Spooner Street,Quahog,RI,02860,$43,5/24/2015
Neil,Goldman,87 Quahog St,Quahog,RI,02860,$35,9/30/2009
Tom,Tucker,45 Pine St,Quahog,RI,02860,$39,11/13/2011
Quagmire,Ida,41 Spooner St,Quahog,RI,02860,$29,2/1/2008
Angela,Smith,25 Pawtucket Ave,Quahog,RI,02860,$98,12/14/2007
Diane,Simmons,23 Oak St,Quahog,RI,02860,$77,7/6/2010
Joyce,Kinney,31 Quahog Rd,Quahog,RI,02860,$14,8/12/2013
Herbert,Oldman,35 Spooner St,Quahog,RI,02860,$61,4/4/2006
Adam,West,55 Elm St,Quahog,RI,02860,$71,1/20/2015